### PR TITLE
docs: create understand eks compute options article

### DIFF
--- a/articles/art0061.md
+++ b/articles/art0061.md
@@ -1,0 +1,147 @@
+---
+title: "Understanding EKS Compute Options: Self-Managed, Managed Node Groups, Fargate, and Karpenter"
+description: A practical guide to EKS compute types and when to use self-managed EC2, managed node groups, Fargate, or Karpenter for your workloads.
+published: true
+series: AWS EKS
+tags: aws, eks, kubernetes, devops
+---
+
+## Introduction
+
+When deploying workloads on Amazon EKS (Elastic Kubernetes Service), one of the most important decisions you'll make is how your pods will run. AWS offers multiple compute options to suit different workload needs, cost models, and operational preferences. This guide breaks down the four major compute types: **Self-Managed EC2 Nodes**, **EKS Managed Node Groups**, **Fargate**, and **Karpenter**.
+
+---
+
+## 1. Self-Managed EC2 Nodes
+
+### Self-Managed EC2: Overview
+
+This is the classic approach where **you provision EC2 instances yourself**, install the necessary components (like kubelet and aws-auth config), and manually join them to your EKS cluster.
+
+### Self-Managed EC2: Benefits
+
+- Full control over instance types, AMIs, disk sizes, and networking
+- Can run any software/agent including privileged containers and daemonsets
+- Works well with custom bootstrapping and hybrid cloud
+
+### Self-Managed EC2: Limitations
+
+- You manage all lifecycle operations: scaling, patching, updates
+- Higher operational overhead
+
+### Self-Managed EC2: Use Cases
+
+- Complex workloads requiring fine-tuned EC2 settings
+- Legacy infrastructure setups
+- New or existing environments that demand full control over infrastructure
+- Teams with strong DevOps expertise
+
+---
+
+## 2. EKS Managed Node Groups ("EKS Auto")
+
+### EKS Managed Node Groups: Overview
+
+A more streamlined EC2 option where **AWS provisions and manages the node group lifecycle for you**. Nodes still run on EC2, but AWS handles bootstrapping, upgrades, and draining during updates. where **AWS provisions and manages the node group lifecycle for you**. Nodes still run on EC2, but AWS handles bootstrapping, upgrades, and draining during updates.
+
+### EKS Managed Node Groups: Benefits
+
+- Simplifies node management without giving up EC2 power
+- Native integration with the EKS control plane
+- Easier updates and cluster maintenance without giving up EC2 power
+- Native integration with the EKS control plane
+- Easier updates and cluster maintenance
+
+### EKS Managed Node Groups: Limitations
+
+- Limited customization (e.g., AMI changes need to follow EKS guidelines)
+- Still requires monitoring and autoscaler setup (e.g., AMI changes need to follow EKS guidelines)
+- Still requires monitoring and autoscaler setup
+
+### EKS Managed Node Groups: Use Cases
+
+- General-purpose workloads
+- Teams that want EC2 flexibility with lower overhead
+- Users new to EKS
+- Teams that want EC2 flexibility with lower overhead
+- Users new to EKS
+
+---
+
+## 3. AWS Fargate for EKS
+
+### Fargate: Overview
+
+A **serverless compute engine** where you run containers without managing any EC2 instances. You define pod specs, and AWS runs them in lightweight, isolated compute environments.
+
+### Fargate: Benefits
+
+- No nodes to manage—AWS handles it all
+- Billing is based on pod vCPU and memory usage
+- Ideal for dev/test environments and short-lived workloads
+
+### Fargate: Limitations
+
+- No support for daemonsets or privileged pods
+- Higher cost at scale compared to EC2
+- Limited observability and fewer tuning knobs
+
+### Fargate: Use Cases
+
+- Simpler apps, microservices, or batch jobs
+- Development and staging environments
+- Teams that prefer not to manage infrastructure
+- Caution: In production environments, consider cost implications and feature limitations such as lack of daemonset or privileged pod support
+
+---
+
+## 4. Karpenter
+
+### Karpenter: Overview
+
+Karpenter is an **open-source cluster autoscaler alternative** developed by AWS that provisions the right compute for each pod in real time. It dynamically launches EC2 instances (including spot) based on workload needs.
+
+### Karpenter: Benefits
+
+- Fast, event-driven autoscaling
+- Smarter instance selection (e.g., cheaper spot, ARM, GPU)
+- Reduces overprovisioning and cost
+
+### Karpenter: Limitations
+
+- Still requires IAM and some infra setup
+- Newer, evolving project—might not fit all orgs
+
+### Karpenter: Use Cases
+
+- Autoscaling-heavy environments
+- Mixed or unpredictable workloads
+- Teams seeking cost optimization
+
+---
+
+## Comparison Table
+
+_Note: Some features like daemonset support may evolve over time or depend on specific platform capabilities._
+
+| Compute Type              | Managed By | Customization | Daemonset Support |
+|--------------------------|------------|----------------|-------------------|
+| Self-Managed EC2 Nodes   | You        | ✅ Full         | ✅ Yes            |
+| EKS Managed Node Groups  | AWS        | ⚠️ Moderate     | ✅ Yes            |
+| Fargate                  | AWS        | ❌ Minimal      | ❌ No             |
+| Karpenter                | AWS + You  | ✅ Dynamic      | ✅ Yes            |
+
+---
+
+## Which Should You Use?
+
+- **Use Self-Managed EC2** if you need deep customization or have existing infra.
+- **Use Managed Node Groups** if you want a balanced approach between flexibility and ease.
+- **Use Fargate** if you want zero infrastructure management and your workloads are simple.
+- **Use Karpenter** if you're optimizing for cost and scale dynamically.
+
+Still not sure? Consider mixing them! EKS supports **multi-compute profiles**, so you can run critical workloads on EC2, bursty tasks on Karpenter, and microservices on Fargate — all in the same cluster. Hybrid strategies are often the most practical in real-world environments, where different types of workloads can benefit from different compute backends.
+
+---
+
+Hope this guide helped you navigate EKS compute options with more clarity. Happy building!


### PR DESCRIPTION
new article: Understanding EKS Compute Options: Self-Managed, Managed Node Groups, Fargate, and Karpenter