### PR TITLE
doc: Set Up gcloud auth and Application Default Credentials article

### DIFF
--- a/articles/art0081.md
+++ b/articles/art0081.md
@@ -1,0 +1,130 @@
+---
+title: 'Best Practice: Set Up gcloud auth and Application Default Credentials (ADC)'
+description: 'Securely configure gcloud authentication using ADC for local development and Terraform workflows.'
+published: true
+tags: 'gcp, gcs, static, terraform'
+---
+
+## 🔐 What is `gcloud auth` Anyway?
+
+The `gcloud` CLI provides multiple ways to authenticate with Google Cloud:
+
+| Method                                  | Use Case                                          |
+| --------------------------------------- | ------------------------------------------------- |
+| `gcloud auth login`                     | Interactive, user-based sessions                  |
+| `gcloud auth application-default login` | Local development with ADC                        |
+| `gcloud auth activate-service-account`  | Automation using static credentials (discouraged) |
+| Workload Identity Federation            | Secure keyless auth for CI/CD                     |
+
+Each method affects how credentials are stored and how they are picked up by SDKs, Terraform, or other tools. For local development, the preferred approach is to use **Application Default Credentials (ADC)**.
+
+---
+
+## 🧪 Local Setup (for Developers)
+
+When developing locally, it’s important to authenticate in a way that’s compatible with the Google Cloud SDK, client libraries, and Terraform. This is best achieved using **Application Default Credentials (ADC)**.
+
+### ✅ Use `gcloud auth application-default login`
+
+> ⚠️ **Post-Login Step:** After logging in, you may see a warning about missing quota project configuration:
+>
+> ```plaintext
+> WARNING: Cannot find a quota project to add to ADC. You might receive a "quota exceeded" or "API not enabled" error.
+> Run $ gcloud auth application-default set-quota-project to add a quota project.
+> ```
+>
+> To fix this, run the following command and **replace `<PROJECT_ID>` with your actual GCP project ID**:
+>
+> ```bash
+> gcloud auth application-default set-quota-project <PROJECT_ID>
+> ```
+>
+> This sets the project that ADC will use for quota and billing purposes. Choose the GCP project you created or intend to work in.
+
+If successful, you’ll see a confirmation like:
+
+````plaintext
+Credentials saved to file: [/home/youruser/.config/gcloud/application_default_credentials.json]
+Quota project "<PROJECT_ID>" was added to ADC which can be used by Google client libraries for billing and quota.
+Note that some services may still bill the project owning the resource.
+``` Choose the GCP project you created or intend to work in.
+
+> 📌 **Note on Account Choice:** If you're just getting started, it's okay to use your personal Gmail address. But for long-term or production work, it's best to use an organizational Google Workspace account tied to your team or company. This enables better access control, audit logging, and separation of concerns.
+
+#### What You'll See
+When you run this command, a browser window will open prompting you to grant access to the **Google Auth Library**. You'll be asked to approve permissions like:
+
+- ✅ *See, edit, configure, and delete your Google Cloud data*
+- ✅ *View and sign in to your Google Cloud SQL instances*
+
+You should **select all checkboxes** and then click **Continue**.
+
+> 🔒 These permissions are required so your local tools (e.g. Terraform, SDKs) can access and manage GCP resources on your behalf. The credentials are stored locally and not shared unless you do so explicitly.
+
+Run the following command:
+
+```bash
+gcloud auth application-default login
+````
+
+This opens a browser for you to log in with your Google account. Upon success, the credentials are stored in:
+
+```bash
+~/.config/gcloud/application_default_credentials.json
+```
+
+These credentials are picked up automatically by:
+
+* Terraform’s `google` and `google-beta` providers
+* GCP client libraries in Python, Go, Node.js, etc.
+* Google SDKs and tools using ADC
+
+> 🧠 **What account should you use?**
+> If you’re just starting out, choose the Google account that you want to associate with your project—this can be your personal Gmail account if you're experimenting. If you’re working in a team or company context, use your organizational Google Workspace account that has the necessary IAM roles (like `Editor` or `Owner`).
+
+### ⚠️ What About `gcloud auth login`?
+
+You can also use:
+
+```bash
+gcloud auth login
+```
+
+This command opens a browser to authenticate with your Google user account and stores the credentials for use **only by the `gcloud` CLI**.
+
+**However**, it does **not** configure Application Default Credentials (ADC), which means tools like Terraform, Python's `google-auth`, and other SDKs will not pick up these credentials.
+
+> ⚠️ **Important:** `gcloud auth login` is useful for CLI-only interactions, but **not sufficient for tools relying on ADC**. For broader compatibility across tools, always use `gcloud auth application-default login` instead.
+
+---
+
+## 🧠 Terraform Example Using ADC
+
+You don’t need to set `credentials` explicitly in your provider block:
+
+```hcl
+provider "google" {
+  project = "my-gcp-project"
+  region  = "us-central1"
+}
+```
+
+Terraform will use the ADC credentials file automatically.
+
+> 🔐 **Best Practice:** Always use ADC (`application-default login`) for dev, and avoid hardcoding paths to service account keys. Treat ADC credentials as sensitive and never commit them to version control.
+
+---
+
+## 🧼 Clean Up (If Needed)
+
+To remove credentials from your machine:
+
+```bash
+gcloud auth application-default revoke
+```
+
+To revoke CLI-only credentials:
+
+```bash
+gcloud auth revoke
+```


### PR DESCRIPTION
new article: Best Practice: Set Up gcloud auth and Application Default Credentials (ADC)