### PR TITLE
docs: Choosing Standard EKS vs EKS Auto Mode

### DIFF
--- a/articles/art0130.md
+++ b/articles/art0130.md
@@ -1,0 +1,219 @@
+---
+title: 'Greenfield EKS: Choosing Standard EKS vs EKS Auto Mode Without Legacy Baggage'
+description: 'Starting your first Amazon EKS cluster? Compare Standard EKS and EKS Auto Mode on cost, operational effort, and control—when you are not migrating an existing platform.'
+published: true
+tags: 'eks, aws, kubernetes, automode'
+---
+
+## Greenfield EKS: Choosing Standard EKS vs EKS Auto Mode Without Legacy Baggage
+
+If you are standing up **your first** [Amazon EKS](https://docs.aws.amazon.com/eks/latest/userguide/what-is-eks.html) cluster and you are **not** dragging along years of Terraform modules, custom AMIs, or a mandated node strategy from another team, the choice between **Standard EKS** (you own how nodes are provisioned and wired) and **[EKS Auto Mode](https://docs.aws.amazon.com/eks/latest/userguide/automode.html)** (AWS runs more of that for you) is mostly about **defaults**: speed and delegated operations versus transparency and fine-grained control. This article is a practical decision guide for that **greenfield** scenario—what differs, how to think about **cost** and **maintenance**, and how to separate **the EKS operating model** from **optional add-ons** you install on top.
+
+![Diagram of Amazon EKS: Kubernetes control plane managed by AWS and worker nodes running in your VPC](https://docs.aws.amazon.com/images/eks/latest/userguide/images/whatis.png)
+
+*Source: [What is Amazon EKS?](https://docs.aws.amazon.com/eks/latest/userguide/what-is-eks.html) (AWS Documentation).*
+
+---
+
+### 1. Overview
+
+This guide helps you decide, for a **new** cluster with **no legacy constraints**:
+
+- What **Standard EKS** and **EKS Auto Mode** each optimize for in the first weeks and months
+- How to compare **cost** at a high level (control plane, compute, Auto Mode management fees, and people time)
+- **Who runs what** (nodes, scaling, ingress/LB), including an **AWS-documented checklist** of what Auto Mode manages as built-in infrastructure
+- A short **rubric** for “default to Auto Mode” versus “start explicit with managed node groups”
+
+---
+
+### 2. Prerequisites
+
+- Familiarity with **containers** and the idea of a **Kubernetes control plane** versus **worker nodes**
+- Access to current **[Amazon EKS pricing](https://aws.amazon.com/eks/pricing)** and **[EKS Auto Mode documentation](https://docs.aws.amazon.com/eks/latest/userguide/automode.html)** for numbers and feature details that change over time
+- No assumption that you already run **Karpenter**, **managed node groups**, or a corporate standard—this article assumes **greenfield**
+
+---
+
+### 3. Name the two starting paths
+
+Same managed control plane; **who owns the node story** is what splits the paths.
+
+#### Side-by-side
+
+| | **Standard EKS** | **EKS Auto Mode** |
+| --- | --- | --- |
+| **You choose** | How nodes are created and scaled: [managed node groups](https://docs.aws.amazon.com/eks/latest/userguide/managed-node-groups.html), self-managed nodes, or later [Karpenter](https://karpenter.sh/) | Less DIY wiring; AWS runs more of **lifecycle + integration** ([docs](https://docs.aws.amazon.com/eks/latest/userguide/automode.html)) |
+| **Mental model** | “These are **my** instances / ASGs, **my** scaling and upgrade path” | “**AWS-shaped** automation; fewer knobs, less assembly” |
+| **APIs you will see** (examples) | EC2, MNG, launch templates, plus whatever provisioner you pick | Platform-oriented CRDs such as `NodePool` / `NodeClaim`, `NodeClass`, `CNINode`, LB-related types—**exact set** varies by version |
+
+#### Standard EKS — responsibility flow
+
+```text
++-------------------------------+
+| AWS: Kubernetes API           |  (managed control plane)
++-------------------------------+
+              |
+              v
++-------------------------------+
+| You: pick node strategy       |
+| MNG / self-managed / Karpenter|
++-------------------------------+
+              |
+              v
++-------------------------------+
+| Workloads / Pods              |
++-------------------------------+
+```
+
+#### EKS Auto Mode — responsibility flow
+
+```text
++-------------------------------+
+| AWS: Kubernetes API           |  (managed control plane)
++-------------------------------+
+              |
+              v
++-------------------------------+
+| AWS: node lifecycle +         |
+| integrations (opinionated)    |
++-------------------------------+
+              |
+              v
++-------------------------------+
+| Workloads / Pods              |
++-------------------------------+
+```
+
+> **Same for both:** observability, backups, secrets, RBAC, network policy, ingress, and mesh are **still yours**. Picking a mode ≠ production-ready.
+
+---
+
+### 4. Cost at a glance
+
+Pricing moves; always verify against the [Amazon EKS pricing page](https://aws.amazon.com/eks/pricing/). The figures below use **US West (Oregon)** On-Demand rates at the time of writing and a **small greenfield** scenario: **one cluster, three worker nodes** (`m5a.xlarge`).
+
+#### Estimated monthly AWS bill
+
+| Line item | Rate | Standard EKS | Auto Mode |
+| --- | --- | --- | --- |
+| **Control plane** | $0.10 / cluster / hr | ~$73 | ~$73 |
+| **EC2 instances** (3 x `m5a.xlarge`) | $0.172 / instance / hr | ~$377 | ~$377 |
+| **Auto Mode management** | $0.02064 / instance / hr | -- | ~$45 |
+| **AWS invoice total** | | **~$450** | **~$495** |
+
+*Source for **$0.02064 / hr** (Auto Mode) and **$0.172 / hr** (EC2) for `m5a.xlarge`: AWS **Example 4: EKS Auto Mode** on [Amazon EKS pricing](https://aws.amazon.com/eks/pricing/) (US West Oregon, On-Demand). Auto Mode fees are **per instance type**; use that page or the [AWS Pricing Calculator for EKS](https://calculator.aws/#/createCalculator/EKS) for other shapes.*
+
+Auto Mode adds roughly **10-12%** to the AWS bill in this scenario. The management fee is billed per-second (one-minute minimum) and applies regardless of EC2 purchase option (On-Demand, Reserved, Savings Plan, or Spot).
+
+> **Watch out for extended support.** If you let a Kubernetes version drift past **standard support** (14 months), the cluster fee jumps to **$0.60 / hr (~$438 / month)**. Plan upgrades regardless of mode.
+
+#### What the invoice does not show
+
+| Hidden cost | Standard EKS | Auto Mode |
+| --- | --- | --- |
+| **Engineer time** building node automation, LB controller Helm charts, upgrade runbooks | Higher -- you build and maintain the glue | Lower -- AWS ships more of that glue |
+| **Incident cost** when nodes misbehave, AMIs drift, or scaling stalls | Yours to debug end-to-end | Shared with AWS; fewer levers but also fewer moving parts you wrote |
+| **Idle capacity** from over-provisioned groups or generous defaults | Risk if you set scaling bounds loosely | Risk if Auto Mode defaults are generous for your workload |
+
+> **Bottom line:** the ~$45 / month management fee in this example is roughly **one hour of a platform engineer's loaded cost**. If Auto Mode saves more than that in reduced toil per month, it pays for itself. If your team already has solid automation and rarely touches nodes, Standard keeps the invoice leaner.
+
+---
+
+### 5. Who runs what—and what the first year feels like
+
+The choice shows up in **division of labor**: who keeps **nodes**, **scaling**, and **traffic into the cluster** healthy. That is what fills your calendar in months **six through twelve**—upgrade planning and Helm charts on one side, AWS platform changes and support cases on the other—not an abstract “mode” badge.
+
+#### Where the work lands
+
+| Area | **Standard EKS (typical greenfield)** | **EKS Auto Mode** |
+| --- | --- | --- |
+| **Nodes and scaling** | You pick the mechanism—[managed node groups](https://docs.aws.amazon.com/eks/latest/userguide/managed-node-groups.html), self-managed nodes, or [Karpenter](https://karpenter.sh/)—and you own **upgrades**, **behavior**, and **capacity tuning** | AWS delivers a more **integrated** node and scaling experience; you align with **Kubernetes objects and practices AWS documents for Auto Mode** instead of assembling the same stack yourself ([Auto Mode](https://docs.aws.amazon.com/eks/latest/userguide/automode.html)) |
+| **Ingress and load balancers** | Teams usually **install and operate** something like **AWS Load Balancer Controller**—chart upgrades, compatibility with new cluster versions, incidents when labels or annotations drift | **More of that integration is AWS-operated** for Auto Mode, so you typically spend **less** time babysitting that slice—still read **AWS release notes** when the platform changes |
+
+#### Standard EKS in practice
+
+- **Clarity and skill-building:** Obvious ownership (“we chose MNG / Karpenter / …”), strong **learning** for engineers who will live in AWS and Kubernetes, and a concrete story when **auditors** ask what creates instances.
+- **Recurring toil:** **Upgrade choreography** across the control plane version, **node AMIs**, and **add-on compatibility**; deliberate choices for **scaling bounds** and instance families; ongoing ownership of **ingress/LB** tooling unless you outsource it elsewhere.
+
+#### EKS Auto Mode in practice
+
+- **Less assembly, faster baseline:** Shorter path to a **working data plane**, fewer Terraform or CloudFormation resources tied to **node plumbing**, and less day-to-day ownership of the **LB integration** layer described above.
+- **Tradeoff:** **Fewer levers** when behavior surprises you; success depends on **solid observability** (logs, metrics, tracing) and comfort escalating or adapting when **AWS-owned** behavior changes.
+
+#### What Auto Mode treats as managed infrastructure (AWS checklist)
+
+AWS describes these as **built-in cluster capabilities**, not as separate EKS console add-ons you install and version yourself. This is the high-level list from [Automate cluster infrastructure with EKS Auto Mode](https://docs.aws.amazon.com/eks/latest/userguide/automode.html) and the **Automated components** section there—use the docs for the latest detail and limits.
+
+##### Compute and nodes
+
+- Data-plane **EC2 instances** (Bottlerocket-based variants): AMI selection, locked-down OS (SELinux enforcing, read-only root), **no direct SSH or SSM** to nodes
+- **Security and lifecycle:** patching and upgrades with minimal disruption; **maximum node lifetime** (default up to **21 days**) so nodes are replaced regularly
+- **Accelerated workloads:** GPU-related kernel drivers and plugins (for example **NVIDIA** and **AWS Neuron**)
+- **Spot:** handling of **Spot interruption notices** and EC2 instance health signals
+
+##### Scaling
+
+- **Karpenter**-style autoscaling: reacts to unschedulable Pods, adds capacity, and removes or consolidates nodes when demand drops
+
+##### Load balancing
+
+- **Elastic Load Balancing** tied to Kubernetes **Service** and **Ingress** objects: provisions and manages **ALB** and **NLB** resources and scales them with cluster demand
+
+##### Networking
+
+- **Pod and Service networking**, including **IPv4/IPv6** and use of **secondary CIDRs** where needed for Pod IP space
+- **Network policy** enforcement for Pods
+- **Cluster DNS** (local DNS for the cluster)
+
+##### Storage
+
+- **EBS CSI**-class block storage as a managed capability
+- **Ephemeral storage** defaults on nodes (volume type, size, encryption, and cleanup behavior on termination—per AWS documentation)
+
+##### Identity
+
+- **EKS Pod Identity:** you **do not** install the **EKS Pod Identity Agent** yourself on Auto Mode clusters (AWS documents that it is not required in this model)
+
+**Neither mode delivers “production in a box.”** Metrics, secret rotation, mesh, policy engines, backups, and business-specific operators remain **your** software lifecycle unless you adopt separate managed services.
+
+**Avoid the “busy cluster” trap.** A Standard environment can *look* heavier because it has **more add-ons** (monitoring, GitOps, security tools). That says what **you installed**, not that **Standard** is inherently more capable than **Auto Mode**. Judge the choice on **who operates nodes and built-in integrations**, not on how crowded the UI feels.
+
+---
+
+### 6. Decision rubric (greenfield, no baggage)
+
+**Lean toward EKS Auto Mode** when:
+
+- The team is **small** and the priority is **shipping** a standard container platform quickly
+- Workloads are **typical** Linux containers without exotic kernel, sysctl, or custom AMI requirements **today**
+- You are comfortable adopting **AWS-shaped** APIs for nodes and integrations for the next phase of growth
+- You prefer **fewer** moving parts **you** must patch and tune in the first year
+
+**Lean toward Standard EKS (often with managed node groups first)** when:
+
+- You want **maximum transparency** into every layer for **training**, **compliance groundwork**, or **multi-cloud** discipline
+- You already know you need **specific** instance families, purchase options, or **strict** cost caps encoded **explicitly** from day one
+- You expect to **standardize** on an in-house or community **node provisioning** story (for example Karpenter you fully control) and want to **learn** that model without an additional management layer
+
+**Default suggestion for a true greenfield product team:** if your main risk is **slow delivery** and **operational overload**, **EKS Auto Mode** is often the better **starting** default; if your main risk is **understanding and owning** every dependency for regulatory or career reasons, **Standard EKS** with **managed node groups** is a clean teaching path. You can revisit the choice after the team has real production traffic and metrics.
+
+---
+
+### 7. Troubleshooting: common misconceptions
+
+- **“Auto Mode is more Kubernetes.”** It is **more AWS-managed automation** exposed through Kubernetes APIs, not a superset of every optional addon.
+- **“Standard is cheaper.”** **Invoice lines** can be lower; **total cost** may not be once you count **engineering time** and **incidents** for a small team.
+- **“We picked a mode, so we are secure and observable.”** **RBAC**, **network policy**, **secrets**, **auditing**, and **monitoring** are still **your** design choices.
+- **“Our Standard cluster has more moving parts, so it must be better.”** Often that is **more optional software you added**—not proof that Standard beats Auto Mode; see **section 5**.
+
+---
+
+### 8. References
+
+- [What is Amazon EKS?](https://docs.aws.amazon.com/eks/latest/userguide/what-is-eks.html)
+- [Amazon EKS pricing](https://aws.amazon.com/eks/pricing/) (see **Example 4: EKS Auto Mode** for per-instance-type Auto Mode fees used in section 4)
+- [EKS Auto Mode](https://docs.aws.amazon.com/eks/latest/userguide/automode.html)
+- [Learn how EKS Auto Mode works](https://docs.aws.amazon.com/eks/latest/userguide/auto-reference.html) (deeper component topics)
+- [Amazon EKS best practices](https://aws.amazon.com/eks/resources/best-practices/)
+- [Managed node groups](https://docs.aws.amazon.com/eks/latest/userguide/managed-node-groups.html)
+- [Karpenter](https://karpenter.sh/)


### PR DESCRIPTION
new article: Greenfield EKS: Choosing Standard EKS vs EKS Auto Mode Without Legacy Baggage